### PR TITLE
OMIM annotation fix for variants falling in multiple genes

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -7,7 +7,8 @@ import os
 def main(report):
     report = parse_functions.apply_parse_spliceAI(report)
     report = parse_functions.apply_zygosity(report)
-    report = parse_functions.add_omim(report)
+    report = parse_functions.apply_add_omim('omim_phenotype', report)
+    report = parse_functions.apply_add_omim('omim_inheritance', report)
     report = parse_functions.apply_alt_depth(report)
     report = parse_functions.apply_ucsc_link(report)
     report = parse_functions.apply_gnomad_link(report)

--- a/parse_report/parse_functions.py
+++ b/parse_report/parse_functions.py
@@ -101,12 +101,30 @@ OMIM_file = os.path.join(
 )
 OMIM = pd.read_csv(OMIM_file, sep="\t")
 OMIM = OMIM.rename(columns={"gene_name": "gene"})
+OMIM = OMIM.dropna(subset=['omim_phenotype'])
 
 
-def add_omim(report):
-    report = pd.merge(report, OMIM, how="left")
-    report["omim_phenotype"] = report["omim_phenotype"].fillna("NA")
-    report["omim_inheritance"] = report["omim_inheritance"].fillna("NA")
+def add_omim(col, gene):
+    if pd.isna(gene):
+        return "NA"
+    else:
+        omim = []
+        gene = gene.split(";")
+        for g in gene:
+            try:
+                omim.append(
+                    str(OMIM[OMIM["gene"] == g][col].values[0])
+                )
+            except IndexError:
+                pass
+        omim = ",".join(omim)
+        return omim
+
+
+def apply_add_omim(col, report):
+    report[col] = report["gene"].apply(lambda x: add_omim(col, x))
+    report[col] = report[col].fillna("NA")
+    report[col] = report[col].replace("", "NA")
     return report
 
 


### PR DESCRIPTION
OMIM annotation fails if the OMIM dataframe is joined directly on the 'gene' column in the report if there are multiple genes (e.g. 'USP21;PPOX;UFC1;RP11-297K8.2'). This fix splits the gene field by ';' and matches each gene against OMIM to retrieve the phenotype and inheritance, returning a list of phenotypes/inheritance for all genes.